### PR TITLE
Make use of the new per-block-sounds

### DIFF
--- a/overrides/Core/blocks/mineral/Stone.block
+++ b/overrides/Core/blocks/mineral/Stone.block
@@ -4,5 +4,6 @@
     "categories": ["stone"],
     "entity": {
         "prefab": "WoodAndStone:StoneBlock"
-    }
+    },
+    "sounds": "Core:stone"
 }

--- a/overrides/Core/blocks/soil/Sand.block
+++ b/overrides/Core/blocks/soil/Sand.block
@@ -4,5 +4,6 @@
     "mass": 32,
     "entity": {
         "prefab": "WoodAndStone:Sand"
-    }
+    },
+    "sounds": "Core:sand"
 }

--- a/overrides/Core/blocks/soil/Snow.block
+++ b/overrides/Core/blocks/soil/Snow.block
@@ -6,5 +6,6 @@
     },
     "entity": {
         "prefab": "WoodAndStone:Snow"
-    }
+    },
+    "sounds": "Core:snow"
 }


### PR DESCRIPTION
WoodAndStone outright overrides some blocks found in the engine. This change makes sure they retain their block sounds.
