### PR TITLE
Biome Per Block Changes For WoodAndStone

### DIFF
--- a/src/main/java/org/terasology/herbalism/generator/HerbForestSpawnDefinition.java
+++ b/src/main/java/org/terasology/herbalism/generator/HerbForestSpawnDefinition.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.herbalism.generator;
 
-import org.terasology.anotherWorld.coreBiome.ForestBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.StaticBlockFloraSpawnDefinition;
@@ -31,7 +31,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class HerbForestSpawnDefinition extends StaticBlockFloraSpawnDefinition {
     public HerbForestSpawnDefinition() {
-        super(PlantType.GRASS, ForestBiome.ID, 0.5f, 0.3f, "Herbalism:Herb",
+        super(PlantType.GRASS, AnotherWorldBiomes.FOREST.getId(), 0.5f, 0.3f, "Herbalism:Herb",
                 Arrays.asList(
                         new BlockUri("WoodAndStone:HerbGeneratedA")/*,
                         new BlockUri("WoodAndStone:Herb2"),

--- a/src/main/java/org/terasology/herbalism/generator/HerbPlainsSpawnDefinition.java
+++ b/src/main/java/org/terasology/herbalism/generator/HerbPlainsSpawnDefinition.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.herbalism.generator;
 
-import org.terasology.anotherWorld.coreBiome.PlainsBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.StaticBlockFloraSpawnDefinition;
@@ -31,7 +31,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class HerbPlainsSpawnDefinition extends StaticBlockFloraSpawnDefinition {
     public HerbPlainsSpawnDefinition() {
-        super(PlantType.GRASS, PlainsBiome.ID, 0.5f, 0.3f, "Herbalism:Herb",
+        super(PlantType.GRASS, AnotherWorldBiomes.PLAINS.getId(), 0.5f, 0.3f, "Herbalism:Herb",
                 Arrays.asList(
                         new BlockUri("WoodAndStone:HerbGeneratedA")/*,
                         new BlockUri("WoodAndStone:Herb2"),

--- a/src/main/java/org/terasology/herbalism/generator/HerbTundraSpawnDefinition.java
+++ b/src/main/java/org/terasology/herbalism/generator/HerbTundraSpawnDefinition.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.herbalism.generator;
 
-import org.terasology.anotherWorld.coreBiome.TundraBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.StaticBlockFloraSpawnDefinition;
@@ -31,7 +31,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class HerbTundraSpawnDefinition extends StaticBlockFloraSpawnDefinition {
     public HerbTundraSpawnDefinition() {
-        super(PlantType.GRASS, TundraBiome.ID, 0.5f, 0.3f, "Herbalism:Herb",
+        super(PlantType.GRASS, AnotherWorldBiomes.TUNDRA.getId(), 0.5f, 0.3f, "Herbalism:Herb",
                 Arrays.asList(
                         new BlockUri("WoodAndStone:HerbGeneratedA")),
                 new BlockCollectionPredicate(Blocks.getBlock("Core:Snow")), null);

--- a/src/main/java/org/terasology/was/generator/WoodAndStoneWorldGenerator.java
+++ b/src/main/java/org/terasology/was/generator/WoodAndStoneWorldGenerator.java
@@ -17,15 +17,10 @@ package org.terasology.was.generator;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.PluggableWorldGenerator;
-import org.terasology.anotherWorld.coreBiome.AlpineBiome;
-import org.terasology.anotherWorld.coreBiome.CliffBiome;
-import org.terasology.anotherWorld.coreBiome.DesertBiome;
-import org.terasology.anotherWorld.coreBiome.ForestBiome;
-import org.terasology.anotherWorld.coreBiome.PlainsBiome;
-import org.terasology.anotherWorld.coreBiome.TaigaBiome;
-import org.terasology.anotherWorld.coreBiome.TundraBiome;
 import org.terasology.anotherWorld.decorator.BeachDecorator;
+import org.terasology.anotherWorld.decorator.BiomeDecorator;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.anotherWorld.decorator.CaveDecorator;
 import org.terasology.anotherWorld.decorator.layering.DefaultLayersDefinition;
@@ -66,6 +61,9 @@ public class WoodAndStoneWorldGenerator extends PluggableWorldGenerator {
 
     @Override
     protected void setupGenerator() {
+
+        addChunkDecorator(new BiomeDecorator());
+
         setSeaLevel(100);
         setMaxLevel(200);
 
@@ -161,13 +159,13 @@ public class WoodAndStoneWorldGenerator extends PluggableWorldGenerator {
 
         LayeringDecorator layering = new LayeringDecorator(config);
 
-        DefaultLayersDefinition desertDef = new DefaultLayersDefinition(DesertBiome.ID);
+        DefaultLayersDefinition desertDef = new DefaultLayersDefinition(AnotherWorldBiomes.DESERT.getId());
         desertDef.addLayerDefinition(new PDist(3, 1), sand, false);
         desertDef.addLayerDefinition(new PDist(4, 2), dirt, true);
         layering.addBiomeLayers(desertDef);
 
-        DefaultLayersDefinition forestDef = new DefaultLayersDefinition(ForestBiome.ID);
-        DefaultLayersDefinition plainsDef = new DefaultLayersDefinition(PlainsBiome.ID);
+        DefaultLayersDefinition forestDef = new DefaultLayersDefinition(AnotherWorldBiomes.FOREST.getId());
+        DefaultLayersDefinition plainsDef = new DefaultLayersDefinition(AnotherWorldBiomes.PLAINS.getId());
         forestDef.addLayerDefinition(new PDist(1, 0), grass, false);
         plainsDef.addLayerDefinition(new PDist(1, 0), grass, false);
         forestDef.addLayerDefinition(new PDist(4, 2), dirt, true);
@@ -175,19 +173,19 @@ public class WoodAndStoneWorldGenerator extends PluggableWorldGenerator {
         layering.addBiomeLayers(forestDef);
         layering.addBiomeLayers(plainsDef);
 
-        DefaultLayersDefinition tundraDef = new DefaultLayersDefinition(TundraBiome.ID);
-        DefaultLayersDefinition taigaDef = new DefaultLayersDefinition(TaigaBiome.ID);
+        DefaultLayersDefinition tundraDef = new DefaultLayersDefinition(AnotherWorldBiomes.TUNDRA.getId());
+        DefaultLayersDefinition taigaDef = new DefaultLayersDefinition(AnotherWorldBiomes.TAIGA.getId());
         tundraDef.addLayerDefinition(new PDist(1, 0), snow, false);
         taigaDef.addLayerDefinition(new PDist(1, 0), snow, false);
         layering.addBiomeLayers(tundraDef);
         layering.addBiomeLayers(taigaDef);
 
-        DefaultLayersDefinition alpineDef = new DefaultLayersDefinition(AlpineBiome.ID);
+        DefaultLayersDefinition alpineDef = new DefaultLayersDefinition(AnotherWorldBiomes.ALPINE.getId());
         alpineDef.addLayerDefinition(new PDist(2f, 1f), ice, false);
         alpineDef.addLayerDefinition(new PDist(1f, 0f), snow, false);
         layering.addBiomeLayers(alpineDef);
 
-        DefaultLayersDefinition cliffDef = new DefaultLayersDefinition(CliffBiome.ID);
+        DefaultLayersDefinition cliffDef = new DefaultLayersDefinition(AnotherWorldBiomes.CLIFF.getId());
         layering.addBiomeLayers(cliffDef);
 
         addChunkDecorator(layering);

--- a/src/main/java/org/terasology/was/generator/plant/forest/grass/GrassForestSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/forest/grass/GrassForestSpawnDefinition.java
@@ -16,8 +16,8 @@
 package org.terasology.was.generator.plant.forest.grass;
 
 import com.google.common.base.Predicate;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.LocalParameters;
-import org.terasology.anotherWorld.coreBiome.ForestBiome;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.StaticBlockFloraSpawnDefinition;
@@ -33,7 +33,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class GrassForestSpawnDefinition extends StaticBlockFloraSpawnDefinition {
     public GrassForestSpawnDefinition() {
-        super(PlantType.GRASS, ForestBiome.ID, 1f, 0.7f, "Core:TallGrass",
+        super(PlantType.GRASS, AnotherWorldBiomes.FOREST.getId(), 1f, 0.7f, "Core:TallGrass",
                 Arrays.asList(new BlockUri("Core:TallGrass1"), new BlockUri("Core:TallGrass2"), new BlockUri("Core:TallGrass3")),
                 new BlockCollectionPredicate(Blocks.getBlock("Core:Grass")),
                 new Predicate<LocalParameters>() {

--- a/src/main/java/org/terasology/was/generator/plant/forest/grass/ShroomForestSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/forest/grass/ShroomForestSpawnDefinition.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.was.generator.plant.forest.grass;
 
-import org.terasology.anotherWorld.coreBiome.ForestBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.StaticBlockFloraSpawnDefinition;
@@ -31,7 +31,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class ShroomForestSpawnDefinition extends StaticBlockFloraSpawnDefinition {
     public ShroomForestSpawnDefinition() {
-        super(PlantType.GRASS, ForestBiome.ID, 0.5f, 0.3f, "Core:Shroom",
+        super(PlantType.GRASS, AnotherWorldBiomes.FOREST.getId(), 0.5f, 0.3f, "Core:Shroom",
                 Arrays.asList(new BlockUri("Core:BigBrownShroom"), new BlockUri("Core:BrownShroom"), new BlockUri("Core:RedShroom")),
                 new BlockCollectionPredicate(Blocks.getBlock("Core:Grass")), null);
     }

--- a/src/main/java/org/terasology/was/generator/plant/forest/tree/BirchForestSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/forest/tree/BirchForestSpawnDefinition.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.was.generator.plant.forest.tree;
 
-import org.terasology.anotherWorld.coreBiome.ForestBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.GrowthBasedPlantSpawnDefinition;
@@ -28,7 +28,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class BirchForestSpawnDefinition extends GrowthBasedPlantSpawnDefinition {
     public BirchForestSpawnDefinition() {
-        super(PlantType.TREE, BirchGrowthDefinition.ID, ForestBiome.ID, 0.6f, 0.8f,
+        super(PlantType.TREE, BirchGrowthDefinition.ID, AnotherWorldBiomes.FOREST.getId(), 0.6f, 0.8f,
                 new BlockCollectionPredicate(Arrays.asList(Blocks.getBlock("Core:Grass"))));
     }
 }

--- a/src/main/java/org/terasology/was/generator/plant/forest/tree/BlueSpruceForestSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/forest/tree/BlueSpruceForestSpawnDefinition.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.was.generator.plant.forest.tree;
 
-import org.terasology.anotherWorld.coreBiome.ForestBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.GrowthBasedPlantSpawnDefinition;
@@ -28,7 +28,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class BlueSpruceForestSpawnDefinition extends GrowthBasedPlantSpawnDefinition {
     public BlueSpruceForestSpawnDefinition() {
-        super(PlantType.TREE, BlueSpruceGrowthDefinition.ID, ForestBiome.ID, 0.2f, 0.4f,
+        super(PlantType.TREE, BlueSpruceGrowthDefinition.ID, AnotherWorldBiomes.FOREST.getId(), 0.2f, 0.4f,
                 new BlockCollectionPredicate(Arrays.asList(Blocks.getBlock("Core:Grass"))));
     }
 }

--- a/src/main/java/org/terasology/was/generator/plant/forest/tree/BroomForestSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/forest/tree/BroomForestSpawnDefinition.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.was.generator.plant.forest.tree;
 
-import org.terasology.anotherWorld.coreBiome.ForestBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.GrowthBasedPlantSpawnDefinition;
@@ -28,7 +28,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class BroomForestSpawnDefinition extends GrowthBasedPlantSpawnDefinition {
     public BroomForestSpawnDefinition() {
-        super(PlantType.TREE, BroomGrowthDefinition.ID, ForestBiome.ID, 0.6f, 0.6f,
+        super(PlantType.TREE, BroomGrowthDefinition.ID, AnotherWorldBiomes.FOREST.getId(), 0.6f, 0.6f,
                 new BlockCollectionPredicate(Arrays.asList(Blocks.getBlock("Core:Grass"))));
     }
 }

--- a/src/main/java/org/terasology/was/generator/plant/forest/tree/CypressForestSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/forest/tree/CypressForestSpawnDefinition.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.was.generator.plant.forest.tree;
 
-import org.terasology.anotherWorld.coreBiome.ForestBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.GrowthBasedPlantSpawnDefinition;
@@ -28,7 +28,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class CypressForestSpawnDefinition extends GrowthBasedPlantSpawnDefinition {
     public CypressForestSpawnDefinition() {
-        super(PlantType.TREE, CypressGrowthDefinition.ID, ForestBiome.ID, 0.4f, 0.8f,
+        super(PlantType.TREE, CypressGrowthDefinition.ID, AnotherWorldBiomes.FOREST.getId(), 0.4f, 0.8f,
                 new BlockCollectionPredicate(Arrays.asList(Blocks.getBlock("Core:Grass"))));
     }
 }

--- a/src/main/java/org/terasology/was/generator/plant/forest/tree/GrandMapleForestSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/forest/tree/GrandMapleForestSpawnDefinition.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.was.generator.plant.forest.tree;
 
-import org.terasology.anotherWorld.coreBiome.ForestBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.GrowthBasedPlantSpawnDefinition;
@@ -28,7 +28,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class GrandMapleForestSpawnDefinition extends GrowthBasedPlantSpawnDefinition {
     public GrandMapleForestSpawnDefinition() {
-        super(PlantType.TREE, GrandMapleGrowthDefinition.ID, ForestBiome.ID, 0.4f, 0.6f,
+        super(PlantType.TREE, GrandMapleGrowthDefinition.ID, AnotherWorldBiomes.FOREST.getId(), 0.4f, 0.6f,
                 new BlockCollectionPredicate(Arrays.asList(Blocks.getBlock("Core:Grass"))));
     }
 }

--- a/src/main/java/org/terasology/was/generator/plant/forest/tree/LongPineForestSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/forest/tree/LongPineForestSpawnDefinition.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.was.generator.plant.forest.tree;
 
-import org.terasology.anotherWorld.coreBiome.ForestBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.GrowthBasedPlantSpawnDefinition;
@@ -28,7 +28,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class LongPineForestSpawnDefinition extends GrowthBasedPlantSpawnDefinition {
     public LongPineForestSpawnDefinition() {
-        super(PlantType.TREE, LongPineGrowthDefinition.ID, ForestBiome.ID, 0.4f, 0.4f,
+        super(PlantType.TREE, LongPineGrowthDefinition.ID, AnotherWorldBiomes.FOREST.getId(), 0.4f, 0.4f,
                 new BlockCollectionPredicate(Arrays.asList(Blocks.getBlock("Core:Grass"))));
     }
 }

--- a/src/main/java/org/terasology/was/generator/plant/forest/tree/MapleForestSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/forest/tree/MapleForestSpawnDefinition.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.was.generator.plant.forest.tree;
 
-import org.terasology.anotherWorld.coreBiome.ForestBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.GrowthBasedPlantSpawnDefinition;
@@ -28,7 +28,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class MapleForestSpawnDefinition extends GrowthBasedPlantSpawnDefinition {
     public MapleForestSpawnDefinition() {
-        super(PlantType.TREE, MapleGrowthDefinition.ID, ForestBiome.ID, 1f, 0.8f,
+        super(PlantType.TREE, MapleGrowthDefinition.ID, AnotherWorldBiomes.FOREST.getId(), 1f, 0.8f,
                 new BlockCollectionPredicate(Arrays.asList(Blocks.getBlock("Core:Grass"))));
     }
 }

--- a/src/main/java/org/terasology/was/generator/plant/forest/tree/OakForestSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/forest/tree/OakForestSpawnDefinition.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.was.generator.plant.forest.tree;
 
-import org.terasology.anotherWorld.coreBiome.ForestBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.GrowthBasedPlantSpawnDefinition;
@@ -28,7 +28,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class OakForestSpawnDefinition extends GrowthBasedPlantSpawnDefinition {
     public OakForestSpawnDefinition() {
-        super(PlantType.TREE, OakGrowthDefinition.ID, ForestBiome.ID, 1f, 0.8f,
+        super(PlantType.TREE, OakGrowthDefinition.ID, AnotherWorldBiomes.FOREST.getId(), 1f, 0.8f,
                 new BlockCollectionPredicate(Arrays.asList(Blocks.getBlock("Core:Grass"))));
     }
 }

--- a/src/main/java/org/terasology/was/generator/plant/forest/tree/PineForestSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/forest/tree/PineForestSpawnDefinition.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.was.generator.plant.forest.tree;
 
-import org.terasology.anotherWorld.coreBiome.ForestBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.GrowthBasedPlantSpawnDefinition;
@@ -28,7 +28,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class PineForestSpawnDefinition extends GrowthBasedPlantSpawnDefinition {
     public PineForestSpawnDefinition() {
-        super(PlantType.TREE, PineGrowthDefinition.ID, ForestBiome.ID, 0.6f, 0.8f,
+        super(PlantType.TREE, PineGrowthDefinition.ID, AnotherWorldBiomes.FOREST.getId(), 0.6f, 0.8f,
                 new BlockCollectionPredicate(Arrays.asList(Blocks.getBlock("Core:Grass"))));
     }
 }

--- a/src/main/java/org/terasology/was/generator/plant/forest/tree/SakuraForestSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/forest/tree/SakuraForestSpawnDefinition.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.was.generator.plant.forest.tree;
 
-import org.terasology.anotherWorld.coreBiome.ForestBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.GrowthBasedPlantSpawnDefinition;
@@ -28,7 +28,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class SakuraForestSpawnDefinition extends GrowthBasedPlantSpawnDefinition {
     public SakuraForestSpawnDefinition() {
-        super(PlantType.TREE, SakuraGrowthDefinition.ID, ForestBiome.ID, 0.2f, 0.6f,
+        super(PlantType.TREE, SakuraGrowthDefinition.ID, AnotherWorldBiomes.FOREST.getId(), 0.2f, 0.6f,
                 new BlockCollectionPredicate(Arrays.asList(Blocks.getBlock("Core:Grass"))));
     }
 }

--- a/src/main/java/org/terasology/was/generator/plant/plains/grass/CornPlainsSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/plains/grass/CornPlainsSpawnDefinition.java
@@ -1,6 +1,6 @@
 package org.terasology.was.generator.plant.plains.grass;
 
-import org.terasology.anotherWorld.coreBiome.PlainsBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.GrowthBasedPlantSpawnDefinition;
@@ -16,7 +16,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class CornPlainsSpawnDefinition extends GrowthBasedPlantSpawnDefinition {
     public CornPlainsSpawnDefinition() {
-        super(PlantType.GRASS, CornGrowthDefinition.ID, PlainsBiome.ID, 0.8f, 0.3f,
+        super(PlantType.GRASS, CornGrowthDefinition.ID, AnotherWorldBiomes.PLAINS.getId(), 0.8f, 0.3f,
                 new BlockCollectionPredicate(Arrays.asList(Blocks.getBlock("Core:Grass"))));
     }
 }

--- a/src/main/java/org/terasology/was/generator/plant/plains/grass/FlowerPlainsSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/plains/grass/FlowerPlainsSpawnDefinition.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.was.generator.plant.plains.grass;
 
-import org.terasology.anotherWorld.coreBiome.PlainsBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.StaticBlockFloraSpawnDefinition;
@@ -31,7 +31,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class FlowerPlainsSpawnDefinition extends StaticBlockFloraSpawnDefinition {
     public FlowerPlainsSpawnDefinition() {
-        super(PlantType.GRASS, PlainsBiome.ID, 0.5f, 1f, "Core:Flower",
+        super(PlantType.GRASS, AnotherWorldBiomes.PLAINS.getId(), 0.5f, 1f, "Core:Flower",
                 Arrays.asList(new BlockUri("Core:Dandelion"), new BlockUri("Core:Iris"),
                         new BlockUri("Core:Lavender"), new BlockUri("Core:RedClover"), new BlockUri("Core:RedFlower"),
                         new BlockUri("Core:Tulip"), new BlockUri("Core:YellowFlower")),

--- a/src/main/java/org/terasology/was/generator/plant/plains/grass/GrassPlainsSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/plains/grass/GrassPlainsSpawnDefinition.java
@@ -16,8 +16,8 @@
 package org.terasology.was.generator.plant.plains.grass;
 
 import com.google.common.base.Predicate;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.LocalParameters;
-import org.terasology.anotherWorld.coreBiome.PlainsBiome;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.StaticBlockFloraSpawnDefinition;
@@ -33,7 +33,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class GrassPlainsSpawnDefinition extends StaticBlockFloraSpawnDefinition {
     public GrassPlainsSpawnDefinition() {
-        super(PlantType.GRASS, PlainsBiome.ID, 1f, 1f, "Core:TallGrass",
+        super(PlantType.GRASS, AnotherWorldBiomes.PLAINS.getId(), 1f, 1f, "Core:TallGrass",
                 Arrays.asList(new BlockUri("Core:TallGrass1"), new BlockUri("Core:TallGrass2"), new BlockUri("Core:TallGrass3")),
                 new BlockCollectionPredicate(Blocks.getBlock("Core:Grass")),
                 new Predicate<LocalParameters>() {

--- a/src/main/java/org/terasology/was/generator/plant/plains/grass/RicePlainsSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/plains/grass/RicePlainsSpawnDefinition.java
@@ -1,6 +1,6 @@
 package org.terasology.was.generator.plant.plains.grass;
 
-import org.terasology.anotherWorld.coreBiome.PlainsBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.GrowthBasedPlantSpawnDefinition;
@@ -16,7 +16,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class RicePlainsSpawnDefinition extends GrowthBasedPlantSpawnDefinition {
     public RicePlainsSpawnDefinition() {
-        super(PlantType.GRASS, RiceGrowthDefinition.ID, PlainsBiome.ID, 0.8f, 0.3f,
+        super(PlantType.GRASS, RiceGrowthDefinition.ID, AnotherWorldBiomes.PLAINS.getId(), 0.8f, 0.3f,
                 new BlockCollectionPredicate(Arrays.asList(Blocks.getBlock("Core:Grass"))));
     }
 }

--- a/src/main/java/org/terasology/was/generator/plant/plains/tree/BroomPlainsSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/plains/tree/BroomPlainsSpawnDefinition.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.was.generator.plant.plains.tree;
 
-import org.terasology.anotherWorld.coreBiome.PlainsBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.GrowthBasedPlantSpawnDefinition;
@@ -28,7 +28,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class BroomPlainsSpawnDefinition extends GrowthBasedPlantSpawnDefinition {
     public BroomPlainsSpawnDefinition() {
-        super(PlantType.TREE, BroomGrowthDefinition.ID, PlainsBiome.ID, 0.6f, 0.3f,
+        super(PlantType.TREE, BroomGrowthDefinition.ID, AnotherWorldBiomes.PLAINS.getId(), 0.6f, 0.3f,
                 new BlockCollectionPredicate(Arrays.asList(Blocks.getBlock("Core:Grass"))));
     }
 }

--- a/src/main/java/org/terasology/was/generator/plant/plains/tree/CypressPlainsSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/plains/tree/CypressPlainsSpawnDefinition.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.was.generator.plant.plains.tree;
 
-import org.terasology.anotherWorld.coreBiome.PlainsBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.GrowthBasedPlantSpawnDefinition;
@@ -28,7 +28,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class CypressPlainsSpawnDefinition extends GrowthBasedPlantSpawnDefinition {
     public CypressPlainsSpawnDefinition() {
-        super(PlantType.TREE, CypressGrowthDefinition.ID, PlainsBiome.ID, 0.5f, 0.2f,
+        super(PlantType.TREE, CypressGrowthDefinition.ID, AnotherWorldBiomes.PLAINS.getId(), 0.5f, 0.2f,
                 new BlockCollectionPredicate(Arrays.asList(Blocks.getBlock("Core:Grass"))));
     }
 }

--- a/src/main/java/org/terasology/was/generator/plant/plains/tree/GrandMaplePlainsSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/plains/tree/GrandMaplePlainsSpawnDefinition.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.was.generator.plant.plains.tree;
 
-import org.terasology.anotherWorld.coreBiome.PlainsBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.GrowthBasedPlantSpawnDefinition;
@@ -28,7 +28,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class GrandMaplePlainsSpawnDefinition extends GrowthBasedPlantSpawnDefinition {
     public GrandMaplePlainsSpawnDefinition() {
-        super(PlantType.TREE, GrandMapleGrowthDefinition.ID, PlainsBiome.ID, 0.6f, 0.05f,
+        super(PlantType.TREE, GrandMapleGrowthDefinition.ID, AnotherWorldBiomes.PLAINS.getId(), 0.6f, 0.05f,
                 new BlockCollectionPredicate(Arrays.asList(Blocks.getBlock("Core:Grass"))));
     }
 }

--- a/src/main/java/org/terasology/was/generator/plant/plains/tree/MaplePlainsSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/plains/tree/MaplePlainsSpawnDefinition.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.was.generator.plant.plains.tree;
 
-import org.terasology.anotherWorld.coreBiome.PlainsBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.GrowthBasedPlantSpawnDefinition;
@@ -28,7 +28,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class MaplePlainsSpawnDefinition extends GrowthBasedPlantSpawnDefinition {
     public MaplePlainsSpawnDefinition() {
-        super(PlantType.TREE, MapleGrowthDefinition.ID, PlainsBiome.ID, 0.5f, 0.2f,
+        super(PlantType.TREE, MapleGrowthDefinition.ID, AnotherWorldBiomes.PLAINS.getId(), 0.5f, 0.2f,
                 new BlockCollectionPredicate(Arrays.asList(Blocks.getBlock("Core:Grass"))));
     }
 }

--- a/src/main/java/org/terasology/was/generator/plant/plains/tree/OakPlainsSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/plains/tree/OakPlainsSpawnDefinition.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.was.generator.plant.plains.tree;
 
-import org.terasology.anotherWorld.coreBiome.PlainsBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.GrowthBasedPlantSpawnDefinition;
@@ -28,7 +28,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class OakPlainsSpawnDefinition extends GrowthBasedPlantSpawnDefinition {
     public OakPlainsSpawnDefinition() {
-        super(PlantType.TREE, OakGrowthDefinition.ID, PlainsBiome.ID, 0.6f, 0.2f,
+        super(PlantType.TREE, OakGrowthDefinition.ID, AnotherWorldBiomes.PLAINS.getId(), 0.6f, 0.2f,
                 new BlockCollectionPredicate(Arrays.asList(Blocks.getBlock("Core:Grass"))));
     }
 }

--- a/src/main/java/org/terasology/was/generator/plant/tundra/tree/BirchTundraSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/tundra/tree/BirchTundraSpawnDefinition.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.was.generator.plant.tundra.tree;
 
-import org.terasology.anotherWorld.coreBiome.TundraBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.GrowthBasedPlantSpawnDefinition;
@@ -28,7 +28,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class BirchTundraSpawnDefinition extends GrowthBasedPlantSpawnDefinition {
     public BirchTundraSpawnDefinition() {
-        super(PlantType.TREE, BirchGrowthDefinition.ID, TundraBiome.ID, 0.3f, 0.6f,
+        super(PlantType.TREE, BirchGrowthDefinition.ID, AnotherWorldBiomes.TUNDRA.getId(), 0.3f, 0.6f,
                 new BlockCollectionPredicate(Arrays.asList(Blocks.getBlock("Core:Snow"))));
     }
 }

--- a/src/main/java/org/terasology/was/generator/plant/tundra/tree/BlueSpruceTundraSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/tundra/tree/BlueSpruceTundraSpawnDefinition.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.was.generator.plant.tundra.tree;
 
-import org.terasology.anotherWorld.coreBiome.TundraBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.GrowthBasedPlantSpawnDefinition;
@@ -28,7 +28,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class BlueSpruceTundraSpawnDefinition extends GrowthBasedPlantSpawnDefinition {
     public BlueSpruceTundraSpawnDefinition() {
-        super(PlantType.TREE, BlueSpruceGrowthDefinition.ID, TundraBiome.ID, 0.7f, 0.3f,
+        super(PlantType.TREE, BlueSpruceGrowthDefinition.ID, AnotherWorldBiomes.TUNDRA.getId(), 0.7f, 0.3f,
                 new BlockCollectionPredicate(Arrays.asList(Blocks.getBlock("Core:Snow"))));
     }
 }

--- a/src/main/java/org/terasology/was/generator/plant/tundra/tree/LongPineTundraSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/tundra/tree/LongPineTundraSpawnDefinition.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.was.generator.plant.tundra.tree;
 
-import org.terasology.anotherWorld.coreBiome.TundraBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.GrowthBasedPlantSpawnDefinition;
@@ -28,7 +28,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class LongPineTundraSpawnDefinition extends GrowthBasedPlantSpawnDefinition {
     public LongPineTundraSpawnDefinition() {
-        super(PlantType.TREE, LongPineGrowthDefinition.ID, TundraBiome.ID, 0.45f, 0.6f,
+        super(PlantType.TREE, LongPineGrowthDefinition.ID, AnotherWorldBiomes.TUNDRA.getId(), 0.45f, 0.6f,
                 new BlockCollectionPredicate(Arrays.asList(Blocks.getBlock("Core:Snow"))));
     }
 }

--- a/src/main/java/org/terasology/was/generator/plant/tundra/tree/OakTundraSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/tundra/tree/OakTundraSpawnDefinition.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.was.generator.plant.tundra.tree;
 
-import org.terasology.anotherWorld.coreBiome.TundraBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.GrowthBasedPlantSpawnDefinition;
@@ -28,7 +28,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class OakTundraSpawnDefinition extends GrowthBasedPlantSpawnDefinition {
     public OakTundraSpawnDefinition() {
-        super(PlantType.TREE, OakGrowthDefinition.ID, TundraBiome.ID, 0.1f, 0.4f,
+        super(PlantType.TREE, OakGrowthDefinition.ID, AnotherWorldBiomes.TUNDRA.getId(), 0.1f, 0.4f,
                 new BlockCollectionPredicate(Arrays.asList(Blocks.getBlock("Core:Snow"))));
     }
 }

--- a/src/main/java/org/terasology/was/generator/plant/tundra/tree/PineTundraSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/tundra/tree/PineTundraSpawnDefinition.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.was.generator.plant.tundra.tree;
 
-import org.terasology.anotherWorld.coreBiome.TundraBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.GrowthBasedPlantSpawnDefinition;
@@ -28,7 +28,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class PineTundraSpawnDefinition extends GrowthBasedPlantSpawnDefinition {
     public PineTundraSpawnDefinition() {
-        super(PlantType.TREE, PineGrowthDefinition.ID, TundraBiome.ID, 0.45f, 0.6f,
+        super(PlantType.TREE, PineGrowthDefinition.ID, AnotherWorldBiomes.TUNDRA.getId(), 0.45f, 0.6f,
                 new BlockCollectionPredicate(Arrays.asList(Blocks.getBlock("Core:Snow"))));
     }
 }

--- a/src/main/java/org/terasology/was/generator/plant/tundra/tree/SpruceTundraSpawnDefinition.java
+++ b/src/main/java/org/terasology/was/generator/plant/tundra/tree/SpruceTundraSpawnDefinition.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.was.generator.plant.tundra.tree;
 
-import org.terasology.anotherWorld.coreBiome.TundraBiome;
+import org.terasology.anotherWorld.AnotherWorldBiomes;
 import org.terasology.anotherWorld.decorator.BlockCollectionPredicate;
 import org.terasology.gf.PlantType;
 import org.terasology.gf.generator.GrowthBasedPlantSpawnDefinition;
@@ -28,7 +28,7 @@ import java.util.Arrays;
 @RegisterPlugin
 public class SpruceTundraSpawnDefinition extends GrowthBasedPlantSpawnDefinition {
     public SpruceTundraSpawnDefinition() {
-        super(PlantType.TREE, SpruceGrowthDefinition.ID, TundraBiome.ID, 0.9f, 0.6f,
+        super(PlantType.TREE, SpruceGrowthDefinition.ID, AnotherWorldBiomes.TUNDRA.getId(), 0.9f, 0.6f,
                 new BlockCollectionPredicate(Arrays.asList(Blocks.getBlock("Core:Snow"))));
     }
 }


### PR DESCRIPTION
Added an UpdateBiome concept to send biome updates (just like block updates) to network clients after the whole chunk has been transferred.
Introduced a BiomeRegistry and Biome interface in the engine module and reworked the ChunkTessellator to use humidity/temperature associated with the block's biome. Future work: Directly specify foliage color in the biome and use that for coloring leaves.
